### PR TITLE
Add support for PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         }
     ],
     "require": {
-        "php": "^7.3",
+        "php": "^7.3|^8.0",
         "illuminate/support": "^8.0"
     },
     "require-dev": {


### PR DESCRIPTION
```txt
php -v && phpunit
PHP 8.0.1 (cli) (built: Jan  8 2021 12:35:09) ( NTS )
Copyright (c) The PHP Group
Zend Engine v4.0.1, Copyright (c) Zend Technologies
    with Xdebug v3.0.2, Copyright (c) 2002-2021, by Derick Rethans
    with Zend OPcache v8.0.1, Copyright (c), by Zend Technologies
PHPUnit 9.5.1 by Sebastian Bergmann and contributors.

Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

.......                                                             7 / 7 (100%)

Time: 00:00.027, Memory: 8.00 MB

OK (7 tests, 85 assertions)
```