### PR TITLE
Fix return type compatibility deprecation notices

### DIFF
--- a/src/DataTransferObject.php
+++ b/src/DataTransferObject.php
@@ -753,7 +753,7 @@ abstract class DataTransferObject implements ArrayAccess, Arrayable, Jsonable, J
      *
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->toArray();
     }
@@ -764,7 +764,7 @@ abstract class DataTransferObject implements ArrayAccess, Arrayable, Jsonable, J
      * @param  mixed  $offset
      * @return bool
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->$offset);
     }
@@ -775,7 +775,7 @@ abstract class DataTransferObject implements ArrayAccess, Arrayable, Jsonable, J
      * @param  mixed  $offset
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return $this->$offset;
     }
@@ -787,7 +787,7 @@ abstract class DataTransferObject implements ArrayAccess, Arrayable, Jsonable, J
      * @param  mixed  $value
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->$offset = $value;
     }
@@ -798,7 +798,7 @@ abstract class DataTransferObject implements ArrayAccess, Arrayable, Jsonable, J
      * @param  mixed  $offset
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->$offset);
     }


### PR DESCRIPTION
On PHP 8.1 this package yields some deprecation notices. I've made the necessary changes to properly resolve this. I've also tested it on PHP 8.0. All green as well.

<details>
<summary><strong>Deprecation Notices (before)</strong></summary>

```
php -v
PHP 8.1.4 (cli) (built: Mar 18 2022 09:32:37) (NTS)
# …

phpunit

Deprecated: Return type of SchulzeFelix\DataTransferObject\DataTransferObject::offsetExists($offset) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /Users/hettiger/Documents/Projekte/2022/2022_04__SchulzeFelix-Laravel-Data-Transfer-Objects/laravel-data-transfer-object/src/DataTransferObject.php on line 767

Deprecated: Return type of SchulzeFelix\DataTransferObject\DataTransferObject::offsetGet($offset) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /Users/hettiger/Documents/Projekte/2022/2022_04__SchulzeFelix-Laravel-Data-Transfer-Objects/laravel-data-transfer-object/src/DataTransferObject.php on line 778

Deprecated: Return type of SchulzeFelix\DataTransferObject\DataTransferObject::offsetSet($offset, $value) should either be compatible with ArrayAccess::offsetSet(mixed $offset, mixed $value): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /Users/hettiger/Documents/Projekte/2022/2022_04__SchulzeFelix-Laravel-Data-Transfer-Objects/laravel-data-transfer-object/src/DataTransferObject.php on line 790

Deprecated: Return type of SchulzeFelix\DataTransferObject\DataTransferObject::offsetUnset($offset) should either be compatible with ArrayAccess::offsetUnset(mixed $offset): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /Users/hettiger/Documents/Projekte/2022/2022_04__SchulzeFelix-Laravel-Data-Transfer-Objects/laravel-data-transfer-object/src/DataTransferObject.php on line 801

Deprecated: Return type of SchulzeFelix\DataTransferObject\DataTransferObject::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /Users/hettiger/Documents/Projekte/2022/2022_04__SchulzeFelix-Laravel-Data-Transfer-Objects/laravel-data-transfer-object/src/DataTransferObject.php on line 756
PHPUnit 9.5.20 #StandWithUkraine

Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

.......                                                             7 / 7 (100%)

Time: 00:00.018, Memory: 8.00 MB

OK (7 tests, 85 assertions)
```
</details>



**After:**

```
php -v
PHP 8.1.4 (cli) (built: Mar 18 2022 09:32:37) (NTS)
# …

phpunit
PHPUnit 9.5.20 #StandWithUkraine

Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

.......                                                             7 / 7 (100%)

Time: 00:00.019, Memory: 8.00 MB

OK (7 tests, 85 assertions)
```